### PR TITLE
fix: Trim down consumer-proguard configuration for gms

### DIFF
--- a/consumer-proguard.pro
+++ b/consumer-proguard.pro
@@ -7,21 +7,3 @@
 -keepclasseswithmembers class * {
   public <init>(android.content.Context, android.util.AttributeSet, int);
  }
-
- # Google Play Services library
-  -keep class * extends java.util.ListResourceBundle {
-   protected Object[ ][ ] getContents();
-}
-
- -keep public class com.google.android.gms.common.internal.safeparcel.SafeParcelable {
-  public static final *** NULL;
- }
-
- -keepnames @com.google.android.gms.common.annotation.KeepName class *
- -keepclassmembernames class * {
-    @com.google.android.gms.common.annotation.KeepName *;
-  }
-
- -keepnames class * implements android.os.Parcelable {
-  public static final ** CREATOR;
- }


### PR DESCRIPTION
## Summery 
reported build failure: 

`ERROR /Users/abhattac/.gradle/caches/transforms-2/files-2.1/383e198825011f96cad28d1edd99dc39/jetified-android-flurry-kit-5.18.1/proguard.txt:13:25: R8: Expected char ';' at /Users/abhattac/.gradle/caches/transforms-2/files-2.1/383e198825011f96cad28d1edd99dc39/jetified-android-flurry-kit-5.18.1/proguard.txt:13:25
  protected Object[ ][ ] getContents();`
  
  I was able to reproduce the bug anytime you are building a proguard-enabled application with the flurry-kit present, but not google-services. I decided we should remove all the proguard configuration related to GMS/play-services because our kit doesn't even use them.

ticket: https://mparticle.tpondemand.com/restui/board.aspx?#page=bug/68840