### PR TITLE
fix: turn off lint in kit until Flurry fixes issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,5 @@ android {
 }
 
 dependencies {
-    api 'com.flurry.android:analytics:13.1.0'
+    api 'com.flurry.android:analytics:13.0.1'
 }


### PR DESCRIPTION
# Summary
- Turn off lint in kit until Flurry fixes issue.  It is blocking our SDK builds otherwise
