### PR TITLE
Fix URL to Flurry integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the [Flurry](https://developer.yahoo.com/analytics/) in
 
 ### Documentation
 
-[Flurry integration](http://docs.mparticle.com/?java#flurry)
+[Flurry integration](https://docs.mparticle.com/integrations/flurry/event/)
 
 ### License
 


### PR DESCRIPTION
# Summary

Adds correct URL to mParticle Flurry integration doc
